### PR TITLE
Allow geoip2 lib to reconnect if connection is nil

### DIFF
--- a/lib/geoip2/client.rb
+++ b/lib/geoip2/client.rb
@@ -73,7 +73,7 @@ module Geoip2
     #
     # @return an instance of Faraday initialized with all that this gem needs
     def connection(faraday_options = {})
-      if @faraday_options != faraday_options
+      if @faraday_options != faraday_options || @connection.nil?
         options = {url: @base_url, parallel_manager: Typhoeus::Hydra.new(max_concurrency: @parallel_requests)}.merge(faraday_options)
         @faraday_options = faraday_options
         @connection = Faraday.new(options) do |conn|


### PR DESCRIPTION
Since the ngeoip connection instance var is memoised, if the connection is initially set to nil it's always passed back as nil. This allows the connection var to be reset if for some reason it ends up being set to nil